### PR TITLE
make function and variable display as table in modules

### DIFF
--- a/src/plugin/context/mixins/members.tsx
+++ b/src/plugin/context/mixins/members.tsx
@@ -12,6 +12,7 @@ import {
 import { OxideContextBase } from '../base';
 import {
   breakable,
+  isMethodContainer,
   isNestedItem,
   isNestedTable,
   join,
@@ -37,11 +38,20 @@ export const MembersMixin = (base: typeof OxideContextBase) =>
         ...groups.flatMap((x) => x.categories ?? [x] as ReflectionSection[]),
       ];
 
+      // Only display non-nested items (like methods) using sections
+      // if the model is a container for it.
+      // This allows functions and variables to be displayed with table
+      // in modules and with sections in classes
+      // similar to how rustdoc handles things
+      const shouldUseSection = isMethodContainer(model);
+
       return (
         <>
           {this.#preview(model)}
           {modules.map((x) => this.#table(x, true))}
-          {sections.map((x) => this.#section(x))}
+          {shouldUseSection
+            ? sections.map((x) => this.#section(x))
+            : sections.map((x) => this.#table(x, true))}
           {tables.map((x) => this.#table(x, true))}
         </>
       );
@@ -50,6 +60,21 @@ export const MembersMixin = (base: typeof OxideContextBase) =>
     #preview(decl: ContainerReflection) {
       if (!decl.isDeclaration()) {
         return;
+      }
+
+      // Functions/overloads: render each signature as a code block with its docs
+      if (decl.signatures?.length) {
+        return decl.signatures.map((sig) => (
+          <>
+            <pre class="item-decl">
+              <code>{transformHighlights(this.memberSignatureTitle(sig))}</code>
+            </pre>
+            <div class="docblock">
+              {this.commentSummary(sig)}
+              {this.commentTags(sig)}
+            </div>
+          </>
+        ));
       }
 
       // Workaround for `this.reflectionPreview`
@@ -86,22 +111,30 @@ export const MembersMixin = (base: typeof OxideContextBase) =>
           </h2>
 
           <dl class="item-table">
-            {section.children.map((item) => (
-              <>
-                <dt>
-                  <a
-                    class={itemLinkClass(item)}
-                    href={this.itemLink(item, forceNested)}
-                    title={item.name}>
-                    {item.name}
-                  </a>
-                </dt>
+            {section.children.map((item) => {
+              let shortSummary = item.comment?.getShortSummary(true);
+              // fallback for functions
+              if (!shortSummary && item.isDeclaration()) {
+                shortSummary = item.signatures?.[0]?.comment?.getShortSummary(true);
+              }
 
-                <dd>
-                  <JSX.Raw html={this.markdown(item.comment?.getShortSummary(true))} />
-                </dd>
-              </>
-            ))}
+              return (
+                <>
+                  <dt>
+                    <a
+                      class={itemLinkClass(item)}
+                      href={this.itemLink(item, forceNested)}
+                      title={item.name}>
+                      {item.name}
+                    </a>
+                  </dt>
+
+                  <dd>
+                    <JSX.Raw html={this.markdown(shortSummary)} />
+                  </dd>
+                </>
+              );
+            })}
           </dl>
         </>
       );

--- a/src/plugin/context/utils.tsx
+++ b/src/plugin/context/utils.tsx
@@ -2,6 +2,7 @@ import * as cheerio from 'cheerio';
 import slug from 'slug';
 import {
   BaseRouter,
+  ContainerReflection,
   DeclarationReflection,
   DefaultThemeRenderContext,
   DocumentReflection,
@@ -24,6 +25,19 @@ export function isNestedTable(section: ReflectionSection) {
 export function isNestedItem(item: ReflectionWithLink) {
   return item.kindOf([
     ReflectionKind.ExportContainer,
+    ReflectionKind.Interface,
+    ReflectionKind.Class,
+    ReflectionKind.Enum,
+  ]);
+}
+
+/**
+ * Check if the item is something that could have methods (associative functions).
+ *
+ * Functions within these are displayed as methods (similar to struct/enum in rustdoc).
+ */
+export function isMethodContainer(item: ContainerReflection) {
+  return item.kindOf([
     ReflectionKind.Interface,
     ReflectionKind.Class,
     ReflectionKind.Enum,


### PR DESCRIPTION
Hi, not sure if you accept PRs...

I think it would be better to render type aliases, functions and variables using table layout in module pages, which is what rustdoc does. This also makes it possible to link to an exported function with `@link` (otherwise it would link to a page where it just shows `let functionName: any`)

Tested with the example:
<img width="2221" height="1309" alt="image" src="https://github.com/user-attachments/assets/adb7e9a1-ac37-4acc-88f6-6ae7f6e4a114" />
<img width="2081" height="448" alt="image" src="https://github.com/user-attachments/assets/19dd6826-7213-4ef1-bfc2-b39d683bd7d7" />
